### PR TITLE
Change type of Fields::workratio to i64

### DIFF
--- a/src/issue_model.rs
+++ b/src/issue_model.rs
@@ -74,7 +74,7 @@ pub struct Fields {
     pub aggregatetimeoriginalestimate: Option<i32>,
     pub progress: Progress,
     pub aggregateprogress: Progress,
-    pub workratio: i32,
+    pub workratio: i64,
     pub summary: String,
     pub creator: User,
     pub project: Project,


### PR DESCRIPTION
I encountered a value that doesn't fit into an i32 in the field. This change fixes the parse error.